### PR TITLE
fix(docs,deps): correct typos and enable golangci-lint installation

### DIFF
--- a/docs/content/contributing/contributors.md
+++ b/docs/content/contributing/contributors.md
@@ -22,4 +22,4 @@ To understand the responsibilities, requirements, and guidelines for becoming a 
 
 ---
 
-We are always looking for more passionate individuals to contribute and take part in the journey of improving Pre-commit Automation Tool. Thank you to all our Contributors for their hard work and dedication! for the community. 🌟
+We are always looking for more passionate individuals to contribute and take part in the journey of improving Pre-commit Automation Tool. Thank you to all our Contributors for their hard work and dedication! 🌟

--- a/docs/content/known-issues/precommit-hooks.md
+++ b/docs/content/known-issues/precommit-hooks.md
@@ -19,7 +19,7 @@ Please check the [open](https://github.com/01cloud/01cloud-githooks/issues) and 
 
 ## 
 
-### Python dependecies not installed
+### Python dependencies not installed
 If you are getting an error like python dependencies not installed, please run the following command in your terminal
 
 **Workaround:**

--- a/golang/install_dependencies.sh
+++ b/golang/install_dependencies.sh
@@ -70,7 +70,7 @@ install_tool_with_asdf() {
         case "$tool" in
             nodejs) plugin_repo="https://github.com/asdf-vm/asdf-nodejs" ;;
             golang) plugin_repo="https://github.com/asdf-community/asdf-golang" ;;
-            # golangci-lint) plugin_repo="https://github.com/hypnoglow/asdf-golangci-lint.git" ;;
+            golangci-lint) plugin_repo="https://github.com/hypnoglow/asdf-golangci-lint.git" ;;
             yamlfmt) plugin_repo="https://github.com/kachick/asdf-yamlfmt" ;;
             gitleaks) plugin_repo="https://github.com/jmcvetta/asdf-gitleaks" ;;
             pre-commit) plugin_repo="git@github.com:jonathanmorley/asdf-pre-commit.git" ;;
@@ -119,7 +119,7 @@ declare -a mandatory_tools=(
     "gitleaks:8.21.0"
     "yamlfmt:latest"
     "pre-commit:3.3.3"
-    # "golangci-lint:1.63.4"
+    "golangci-lint:1.63.4"
 )
 
 # List of optional tools


### PR DESCRIPTION
## Description
fix(docs,deps): correct typos and enable golangci-lint installation
- Fixed typo "dependecies" to "dependencies" in precommit-hooks.md
- Removed redundant "for the community" text in contributors.md
- Uncommented golangci-lint plugin and version in install_dependencies.sh to enable its installation

## Changes
Changes to be committed:
      modified:   docs/content/contributing/contributors.md
      modified:   docs/content/known-issues/precommit-hooks.md
      modified:   golang/install_dependencies.sh